### PR TITLE
Fix fail in getting values from dac4 box for ac4

### DIFF
--- a/CTAWAVE/CTAWAVE_SelectionSet.php
+++ b/CTAWAVE/CTAWAVE_SelectionSet.php
@@ -392,7 +392,7 @@ function getMediaProfile($xml,$handler_type,$repCount, $adaptCount,$opfile)
             if($brand_pos!==False)
                 $xml_MPParameters['brand']=substr($compatible_brands,$brand_pos,$brand_pos+3);
             
-            $dac4=$sounSampleDes->getElementsByTagName("dac4");
+            $dac4=$sounSampleDes->getElementsByTagName("ac4_dsi_v1");
             if($dac4->length>0){
                 if($dac4->item(0)->hasAttribute("mdcompat_0"))//if(isset($attr["mdcompat_0"]))
                      $xml_MPParameters['level']=$dac4->item(0)->getAttribute("mdcompat_0");


### PR DESCRIPTION
mdcompat_0 cannot be read correctly. The node should be ac4_dsi_v1 where the mdcompat_0 is located.

<dac4>
<ac4_dsi_v1 ... mdcompat_0="0"...>
</ac4_dsi_v1>
</dac4>
